### PR TITLE
Remove array/string offset access via curly braces.

### DIFF
--- a/src/FilesystemIterator.php
+++ b/src/FilesystemIterator.php
@@ -41,7 +41,7 @@ class FilesystemIterator implements RecursiveIterator, Countable, SeekableIterat
     public function __construct(Filesystem $fs, string $dir = '/', array $options = [])
     {
         $this->fs = $fs;
-        $this->dir = $dir{strlen($dir)-1} !== '/' ? $dir . '/' : $dir;
+        $this->dir = $dir[strlen($dir)-1] !== '/' ? $dir . '/' : $dir;
         $this->options = Options::fromArray($options);
         $this->list = $this->fs->listContents($this->dir);
         $this->updateItem();


### PR DESCRIPTION
As of PHP 7.4, using curly braces for array/string offset has been [deprecated](https://wiki.php.net/rfc/deprecate_curly_braces_array_access), as its support was undocumented and unpredictable, and as the square brackets did all of the same things.

This PR simply swaps one for the still-supported square brackets, preventing a deprecation warning from being thrown on PHP 7.4.